### PR TITLE
Adds recording of username when available.

### DIFF
--- a/translator/instance_generator.py
+++ b/translator/instance_generator.py
@@ -129,7 +129,7 @@ class InstanceGenerator():
         '''
         return uid in self.created_users
 
-    def create_user_principal(self, uid, host, source):
+    def create_user_principal(self, uid, host, source, username):
         ''' Create a user principal, add it to the created list, and return it
         '''
         record = {}
@@ -137,7 +137,10 @@ class InstanceGenerator():
         principal["uuid"] = self.create_uuid("uid", str(uid)+host)
         principal["type"] = "PRINCIPAL_LOCAL"
         principal["userId"] = str(uid)
-#         principal["username"] = ""
+        if uid == 0:
+            principal["username"] = "root"
+        elif username is not None:
+            principal["username"] = username
         principal["groupIds"] = []
         principal["properties"] = {}
 

--- a/translator/translator.py
+++ b/translator/translator.py
@@ -193,7 +193,7 @@ class CDMTranslator(object):
         uid = cadets_record["uid"]
         if not ig.get_user_id(uid):
             self.logger.debug("Creating new User Principal for %d", uid)
-            principal = ig.create_user_principal(uid, cadets_record["host"], self.get_source())
+            principal = ig.create_user_principal(uid, cadets_record["host"], self.get_source(), cadets_record.get("username"))
             datums.append(principal)
 
         # Create a new Process subject if necessary
@@ -226,7 +226,7 @@ class CDMTranslator(object):
                 unknown_uid = -1
                 if not ig.get_user_id(unknown_uid):
                     self.logger.debug("Creating new User Principal for %d", unknown_uid)
-                    principal = ig.create_user_principal(unknown_uid, cadets_record["host"], self.get_source())
+                    principal = ig.create_user_principal(unknown_uid, cadets_record["host"], self.get_source(), cadets_record.get("username"))
                     principal["datum"]["username"] = "UNKNOWN"
                     datums.append(principal)
 

--- a/translator/translator.py
+++ b/translator/translator.py
@@ -372,7 +372,7 @@ class CDMTranslator(object):
         record = {}
         event = {}
 
-        if provider == "audit":
+        if provider == "audit" or (provider == "sdt" and call == "pam_authenticate"):
             event["type"] = self.convert_audit_event_type(call)
         else:
             self.logger.warning("Unexpected provider %s", provider)
@@ -446,6 +446,8 @@ class CDMTranslator(object):
             event["properties"]["address"] = str(cadets_record["address"])
         if "port" in cadets_record:
             event["properties"]["port"] = str(cadets_record["port"])
+        if "username" in cadets_record:
+            event["properties"]["username"] = str(cadets_record["username"])
 
         event["properties"]["exec"] = cadets_record["exec"]
 


### PR DESCRIPTION
When username is available it will be written into the CDM Principal
record. Using `cadets_record.get("username") retruns `None` when the
field does not exist.

We expect to get username from libpam.